### PR TITLE
buildFutureオプションの追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "docs"
-command = "hugo --gc --minify"
+command = "hugo --gc --minify --buildFuture"
 
 [context.production.environment]
 HUGO_VERSION = "0.69.0"


### PR DESCRIPTION
## 概要
- hugoがHTML等を生成する際に、未来の更新日を含めて生成するオプション(`--buildFuture`)を追加する

## 詳細
- 更新日時が4/7の記事がNetlifyに反映されない問題が発生している
- 原因は`production`のコマンドに`--buildFuture`が入っていないため、NetlifyのタイムゾーンによってはHTMLが生成されない場合がある